### PR TITLE
Adds custom error with attr for needed bytes count

### DIFF
--- a/lib/cbor-pure.rb
+++ b/lib/cbor-pure.rb
@@ -4,6 +4,17 @@ require "half.rb"
 
 
 class CBOR
+  class OutOfBytesError < RuntimeError
+    def initialize(bytes)
+      @bytes = bytes
+    end
+
+    def to_s
+      "Out of bytes to decode: #{@bytes}"
+    end
+    attr_reader :bytes
+  end
+
   module Streaming
     def cbor_stream?
       @cbor_streaming
@@ -174,7 +185,7 @@ class CBOR
   def take(n)
     opos = @pos
     @pos += n
-    raise "Out of bytes to decode: #{opos} + #{n} > #{@buffer.bytesize}" if @pos > @buffer.bytesize
+    raise OutOfBytesError.new(@pos - @buffer.bytesize) if @pos > @buffer.bytesize
     @buffer[opos, n]
   end
 


### PR DESCRIPTION
Utilizing the nature of CBOR to communicate the amount of bytes to read,
a server implementation can use this error to implement byte-precise
reads from a socket, although "byte-precise" in a socket context has to
be taken with a grain of salt due to several possible instances of
buffering from wire to socket to server.
