### PR TITLE
format sequences to pretty mode

### DIFF
--- a/bin/cborseq2pretty.rb
+++ b/bin/cborseq2pretty.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require 'cbor-pure'
+require 'treetop'
+require 'cbor-diag-parser'
+require 'cbor-diagnostic'
+require 'cbor-pretty'
+
+options = ''
+while /\A-([etu]+)\z/ === ARGV[0]
+  options << $1
+  ARGV.shift
+end
+
+ARGF.binmode
+i = ARGF.read
+while !i.empty?
+  o, i = CBOR.decode_with_rest(i)
+  puts CBOR::pretty(CBOR::encode(o))
+  if !i.empty?
+    print "\n,\n"
+  end
+end


### PR DESCRIPTION
This might not be the best way, decoding, encoding and then decoding again.
But it works.
It puts a comma/blank-line between pretty renditions.  Maybe the comma should be behind a #, so that the hex is accurate to the original sequence.
