### PR TITLE
maybe accept single digit hexadecimal

### DIFF
--- a/bin/pretty2diag.rb
+++ b/bin/pretty2diag.rb
@@ -4,7 +4,7 @@ require 'cbor-diagnostic'
 
 
 def extractbytes(s)
-  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
+  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]?/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
 end
 
 

--- a/bin/pretty2diag.rb
+++ b/bin/pretty2diag.rb
@@ -4,7 +4,7 @@ require 'cbor-diagnostic'
 
 
 def extractbytes(s)
-  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]?/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
+  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F\s]/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
 end
 
 


### PR DESCRIPTION
Given a rust debug {:x?} dump like:

    voucher: [d2, 84, 43, a1, 1, 26, a0, 58, 2a, a1, 19, 9, c5, a3, 1, 69, 70, 72, 6f, 78, 69, 6d, 69, 74, 79, 2, c1, 1a, 5f, 50, 1d, d2, d, 71, 30, 30, 2d, 44, 30, 2d, 45, 35, 2d, 46, 32, 2d, 30, 30, 2d, 30, 32, 40]

I want to examine it with pretty2diag.rb.  I remove the , from the output, since that's not accepted, but get complaints about it being too short.  After some head scratching, I realize that the single hex digits are the problem:

   d2 84 43 a1 01 26 a0 58 2a a1 19 09 c5 a3 01 69 70 72 6f 78 69 6d 69 74 79 02 c1 1a 5f 50 1d d2 0d 71 30 30 2d 44 30 2d 45 35 2d 46 32 2d 30 30 2d 30 32 40

and this works.  

Looking at `pretty2diag.rb`, I see that it insists on every byte having two digits.  Well... that is good if there are no spaces.
After thinking about this for a bit, I think that if we accept space as being the second digit, then it works out right, but I don't have enough test data to be sure about this.

