### PR TITLE
move extractbytes into CBOR module

### DIFF
--- a/bin/pretty2cbor.rb
+++ b/bin/pretty2cbor.rb
@@ -2,9 +2,4 @@
 require 'cbor-pure'
 require 'cbor-pretty'
 
-
-def extractbytes(s)
-  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
-end
-
-print(extractbytes(ARGF))
+print(CBOR.extract_bytes_from_hex(ARGF))

--- a/bin/pretty2diag.rb
+++ b/bin/pretty2diag.rb
@@ -3,15 +3,10 @@ require 'cbor-pretty'
 require 'cbor-diagnostic'
 
 
-def extractbytes(s)
-  s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
-end
-
-
 require 'cbor-diagnostic-helper'
 options = cbor_diagnostic_process_args("cdetpqu")
 
 
-i = extractbytes(ARGF)
+i = CBOR.extract_bytes_from_hex(ARGF)
 o = CBOR.decode(i)
 puts cbor_diagnostic_output(o, options)

--- a/lib/cbor-pretty.rb
+++ b/lib/cbor-pretty.rb
@@ -17,6 +17,11 @@ end
 
 
 module CBOR
+
+  def self.extract_bytes_from_hex(s)
+    s.each_line.map {|ln| ln.sub(/#.*/, '')}.join.scan(/[0-9a-fA-F][0-9a-fA-F]/).map {|b| b.to_i(16).chr(Encoding::BINARY)}.join
+  end
+
   def self.pretty(s, indent = 0, max_target = 40)
     Buffer.new(s).pretty_item_final(indent, max_target)
   end
@@ -38,7 +43,7 @@ module CBOR
     @out << s.hexbytes
     s
   end
-  
+
   def pretty_item_streaming(ib)
     res = nil
     @out << " # #{MT_NAMES[ib >> 5]}(*)\n"


### PR DESCRIPTION
so it can be re-used and others can parse pretty.
(Needs some test cases)
