### PR TITLE
docs: add cbor2u8 script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Specifically, the tools...
 * cbor2diag.rb
 * cbor2json.rb
 * cbor2pretty.rb
-* cbor2yaml.rb
 * cbor2u8.rb
+* cbor2yaml.rb
 * cborseq2diag.rb
 * cborseq2json.rb
 * cborseq2neatjson.rb

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Specifically, the tools...
 * "neatjson" is a neater form of JSON.
 * "pretty" is the pretty-printed representation of binary CBOR as used by
   [cbor.me](http://cbor.me).
+* "u8" is a sequence of bytes represented as comma-terminated hex
+  numbers, eight per line, suitable for inclusion into a C-language
+  array of u8 bytes.
 * "yaml" is [YAML](https://yaml.org).
 
 [DN]: https://www.rfc-editor.org/rfc/rfc8949#name-diagnostic-notation

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Specifically, the tools...
 * cbor2json.rb
 * cbor2pretty.rb
 * cbor2yaml.rb
+* cbor2u8.rb
 * cborseq2diag.rb
 * cborseq2json.rb
 * cborseq2neatjson.rb


### PR DESCRIPTION
While working with these tools, I found the `cbor2u8.rb` script very useful, but I noticed that is not listed in the "Command line utilities" section in the README. I'm not sure if there is any reason for this, in any case I think it should be there!